### PR TITLE
[cases] case screen basic layout

### DIFF
--- a/src/Components/CaseCard/CaseCard.tsx
+++ b/src/Components/CaseCard/CaseCard.tsx
@@ -12,7 +12,20 @@ function CaseCard(caseData: Case) {
       onPress={() =>
         router.push({
           pathname: '/Cases/CaseScreen',
-          params: { caseData },
+          params: {
+            id: caseData.id,
+            approved: caseData.approved,
+            title: caseData.title,
+            blurb: caseData.blurb,
+            summary: caseData.summary,
+            image: caseData.image,
+            caseSite: caseData.caseSite,
+            claimLink: caseData.claimLink,
+            optOutLink: caseData.optOutLink,
+            caseStatus: caseData.caseStatus,
+            date: caseData.date,
+            lawFirm: caseData.lawFirm,
+          },
         })
       }
     >

--- a/src/Components/CaseCard/CaseCard.tsx
+++ b/src/Components/CaseCard/CaseCard.tsx
@@ -1,3 +1,4 @@
+import { router } from 'expo-router';
 import React from 'react';
 import { Image, Text, TouchableOpacity, View } from 'react-native';
 
@@ -13,7 +14,10 @@ type CaseCardProps = {
 
 function CaseCard({ id, title, caseStatus, image }: CaseCardProps) {
   return (
-    <TouchableOpacity style={styles.caseCard}>
+    <TouchableOpacity
+      style={styles.caseCard}
+      onPress={() => router.push('/Cases/CaseScreen')}
+    >
       <View style={styles.infoContainer}>
         <Text style={styles.titleText} adjustsFontSizeToFit>
           {title}

--- a/src/Components/CaseCard/CaseCard.tsx
+++ b/src/Components/CaseCard/CaseCard.tsx
@@ -3,33 +3,31 @@ import React from 'react';
 import { Image, Text, TouchableOpacity, View } from 'react-native';
 
 import styles from './styles';
-import { CaseUid } from '../../types/types';
+import { Case } from '../../types/types';
 
-type CaseCardProps = {
-  id: CaseUid;
-  title: string;
-  caseStatus: string;
-  image: string;
-};
-
-function CaseCard({ id, title, caseStatus, image }: CaseCardProps) {
+function CaseCard(caseData: Case) {
   return (
     <TouchableOpacity
       style={styles.caseCard}
-      onPress={() => router.push('/Cases/CaseScreen')}
+      onPress={() =>
+        router.push({
+          pathname: '/Cases/CaseScreen',
+          params: { caseData },
+        })
+      }
     >
       <View style={styles.infoContainer}>
         <Text style={styles.titleText} adjustsFontSizeToFit>
-          {title}
+          {caseData.title}
         </Text>
         <View style={styles.statusContainer}>
-          <Text style={styles.statusText}>{caseStatus}</Text>
+          <Text style={styles.statusText}>{caseData.caseStatus}</Text>
         </View>
       </View>
       <Image
         style={styles.imagePlaceholder}
         source={{
-          uri: image,
+          uri: caseData.image,
         }}
       />
     </TouchableOpacity>

--- a/src/Components/CaseCard/CaseCard.tsx
+++ b/src/Components/CaseCard/CaseCard.tsx
@@ -11,7 +11,7 @@ function CaseCard(caseData: Case) {
       style={styles.caseCard}
       onPress={() =>
         router.push({
-          pathname: '/Cases/CaseScreen',
+          pathname: `/Cases/CaseScreen`,
           params: {
             id: caseData.id,
             approved: caseData.approved,

--- a/src/Components/CaseStatusBar/CaseStatusBar.tsx
+++ b/src/Components/CaseStatusBar/CaseStatusBar.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function CaseStatusBar() {
+  return (
+    <View>
+      <Text>CaseStatusBar</Text>
+    </View>
+  );
+}

--- a/src/Components/CaseSummaryCard/CaseSummarCard.tsx
+++ b/src/Components/CaseSummaryCard/CaseSummarCard.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function CaseSummaryCard() {
+  return (
+    <View>
+      <Text>CaseSummaryCard</Text>
+    </View>
+  );
+}

--- a/src/Components/EducationalBar/EducationalBar.tsx
+++ b/src/Components/EducationalBar/EducationalBar.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function EducationalBar() {
+  return (
+    <View>
+      <Text>EducationalBar</Text>
+    </View>
+  );
+}

--- a/src/Components/EligibilityCard/EligibilityCard.tsx
+++ b/src/Components/EligibilityCard/EligibilityCard.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function EligibilityCard() {
+  return (
+    <View>
+      <Text>EligibilityCard</Text>
+    </View>
+  );
+}

--- a/src/Components/FormsCard/FormsCard.tsx
+++ b/src/Components/FormsCard/FormsCard.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function FormsCard() {
+  return (
+    <View>
+      <Text>FormsCard</Text>
+    </View>
+  );
+}

--- a/src/app/(BottomTabNavigation)/Cases/CaseScreen/index.tsx
+++ b/src/app/(BottomTabNavigation)/Cases/CaseScreen/index.tsx
@@ -1,10 +1,15 @@
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 
 import styles from './styles';
+import { Case } from '../../../../types/types';
 
 function CasesScreen() {
+  const caseData = useLocalSearchParams() as unknown as Case;
+
+  console.log(caseData);
+
   return (
     <View style={styles.container}>
       <View style={styles.headerContainer}>

--- a/src/app/(BottomTabNavigation)/Cases/CaseScreen/index.tsx
+++ b/src/app/(BottomTabNavigation)/Cases/CaseScreen/index.tsx
@@ -1,0 +1,19 @@
+import { router } from 'expo-router';
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+
+import styles from './styles';
+
+function CasesScreen() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerContainer}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.button}>
+          <Text>Go Back</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+export default CasesScreen;

--- a/src/app/(BottomTabNavigation)/Cases/CaseScreen/index.tsx
+++ b/src/app/(BottomTabNavigation)/Cases/CaseScreen/index.tsx
@@ -3,6 +3,11 @@ import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 
 import styles from './styles';
+import CaseStatusBar from '../../../../Components/CaseStatusBar/CaseStatusBar';
+import CaseSummaryCard from '../../../../Components/CaseSummaryCard/CaseSummarCard';
+import EducationalBar from '../../../../Components/EducationalBar/EducationalBar';
+import EligibilityCard from '../../../../Components/EligibilityCard/EligibilityCard';
+import FormsCard from '../../../../Components/FormsCard/FormsCard';
 import { Case } from '../../../../types/types';
 
 function CasesScreen() {
@@ -17,6 +22,11 @@ function CasesScreen() {
           <Text>Go Back</Text>
         </TouchableOpacity>
       </View>
+      <CaseStatusBar />
+      <CaseSummaryCard />
+      <EligibilityCard />
+      <FormsCard />
+      <EducationalBar />
     </View>
   );
 }

--- a/src/app/(BottomTabNavigation)/Cases/CaseScreen/styles.tsx
+++ b/src/app/(BottomTabNavigation)/Cases/CaseScreen/styles.tsx
@@ -1,0 +1,38 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    backgroundColor: '#fff',
+  },
+  headerContainer: {
+    flex: 0.2,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    width: '100%',
+    paddingRight: 30,
+  },
+  casesContainer: {
+    flex: 0.8,
+    flexDirection: 'column',
+    width: '90%',
+  },
+  circle: {
+    width: 70,
+    height: 70,
+    borderRadius: 100 / 2,
+    backgroundColor: '#a9a9a9',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    margin: 10,
+    alignItems: 'center',
+    backgroundColor: '#339FFF',
+    padding: 10,
+  },
+});

--- a/src/app/(BottomTabNavigation)/Cases/CaseScreen/styles.tsx
+++ b/src/app/(BottomTabNavigation)/Cases/CaseScreen/styles.tsx
@@ -16,19 +16,6 @@ export default StyleSheet.create({
     width: '100%',
     paddingRight: 30,
   },
-  casesContainer: {
-    flex: 0.8,
-    flexDirection: 'column',
-    width: '90%',
-  },
-  circle: {
-    width: 70,
-    height: 70,
-    borderRadius: 100 / 2,
-    backgroundColor: '#a9a9a9',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
   button: {
     margin: 10,
     alignItems: 'center',

--- a/src/app/(BottomTabNavigation)/Cases/index.tsx
+++ b/src/app/(BottomTabNavigation)/Cases/index.tsx
@@ -58,7 +58,7 @@ function CasesScreen() {
               <FlatList
                 data={cases}
                 renderItem={({ item }) => <CaseCard {...item} />}
-                keyExtractor={item => String(item.id)}
+                keyExtractor={item => item.id}
               />
             )}
           </>

--- a/src/app/(BottomTabNavigation)/Cases/index.tsx
+++ b/src/app/(BottomTabNavigation)/Cases/index.tsx
@@ -57,14 +57,7 @@ function CasesScreen() {
             ) : (
               <FlatList
                 data={cases}
-                renderItem={({ item }) => (
-                  <CaseCard
-                    id={item.id}
-                    title={item.title}
-                    caseStatus={item.caseStatus}
-                    image={item.image}
-                  />
-                )}
+                renderItem={({ item }) => <CaseCard {...item} />}
                 keyExtractor={item => String(item.id)}
               />
             )}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -12,15 +12,13 @@ function StartScreen() {
     //     router.replace('/Welcome');
     //   }
     // });
-    const { data: authListener } = supabase.auth.onAuthStateChange(
-      (_event, session) => {
-        if (session) {
-          router.replace('/Cases');
-        } else {
-          router.replace('Welcome');
-        }
-      },
-    );
+    supabase.auth.onAuthStateChange((_event, session) => {
+      if (session) {
+        router.replace('/Cases');
+      } else {
+        router.replace('Welcome');
+      }
+    });
     // return () => authListener.subscription.unsubscribe();
   }, []);
 }

--- a/src/supabase/queries/cases.ts
+++ b/src/supabase/queries/cases.ts
@@ -79,7 +79,7 @@ export async function getCasesByIds(caseIds: CaseUid[]): Promise<Case[]> {
  */
 export function parseCase(item: any): Case {
   const formattedCase: Case = {
-    id: item.id,
+    id: item.caseId,
     approved: item.approved,
     title: item.title,
     blurb: item.blurb,


### PR DESCRIPTION
## What's new in this PR

### Description

- Create basic case screen layout for MPH.
- Implement navigation from Cases screen, passing case data through navigation parameters.

[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

### Screenshots
<img src="https://github.com/calblueprint/impact-fund/assets/66931067/8b7753f0-28bd-4b4a-9d12-c623258fd28c" width="240" height="540">

## How to Review
- Login with an account that's involved with one or more cases.
    - If not, go to supabase and add a UserUid<->CaseUid pairing in the `status` table.
- Press on case card to navigate to case specific screen.
- Observe case data logged to the console.

## Next steps
- Build the rest of the case screen!!

### Online sources
[Expo Navigation Docs](https://docs.expo.dev/router/reference/search-parameters/)

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

CC: @stephaniewong2
