### PR TITLE
Enable routing from eligibility form to case screen

### DIFF
--- a/src/app/(BottomTabNavigation)/AllCases/CaseScreen/index.tsx
+++ b/src/app/(BottomTabNavigation)/AllCases/CaseScreen/index.tsx
@@ -30,13 +30,7 @@ function CasesScreen() {
           <Text style={styles.title}>{caseData.title}</Text>
         </View>
         <CaseStatusBar />
-        {status === Eligibility.ELIGIBLE && (
-          <EligibilityCard caseData={caseData} status={status} />
-        )}
-        {(status === Eligibility.INELIGIBLE ||
-          status === Eligibility.UNDETERMINED) && (
-          <EligibilityCard caseData={caseData} status={status} />
-        )}
+        {status && <EligibilityCard caseData={caseData} status={status} />}
         <CaseSummaryCard {...caseData} />
         <FormsCard />
         <EducationalBar />

--- a/src/app/(BottomTabNavigation)/AllCases/EligibilityForm/index.tsx
+++ b/src/app/(BottomTabNavigation)/AllCases/EligibilityForm/index.tsx
@@ -5,7 +5,10 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import styles from './styles';
 import RightArrow from '../../../../../assets/right-arrow.svg';
-import { updateCaseStatus } from '../../../../supabase/queries/cases';
+import {
+  getCaseById,
+  updateCaseStatus,
+} from '../../../../supabase/queries/cases';
 import { CaseUid, Eligibility } from '../../../../types/types';
 
 export default function EligibilityForm() {
@@ -13,7 +16,9 @@ export default function EligibilityForm() {
 
   const updateEligibility = async (status: Eligibility) => {
     await updateCaseStatus(caseId, status);
-    router.push('/AllCases/CaseScreen');
+    getCaseById(caseId).then(res => {
+      router.push({ pathname: '/AllCases/CaseScreen', params: { ...res } });
+    });
   };
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## What's new in this PR
Added functionality to enable routing from eligibility form back to case screen and have it be updated.

### Description

[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

After updating the eligibility by pressing one of the eligibility option buttons, we re-fetch the case from Supabase, and pass that as a route parameter to the Case screen in order for it to properly render the new update. 

### Screenshots

[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy!"

## How to review

[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

Click into a CaseCard to go into the Case screen, and navigate to the Eligibility form. Try opting in, and then you should be taken back to the Case screen, but have the info presented be updated to show you the proper changes.

## Next steps

[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."

This is a version 1 solution. I think ideally what we would want is to create dynamic routing for the CaseScreen where it can take the caseId as the parameter. Then we probably want to lift the state of status up so that both the CaseScreen and EligibilityForm (and anything else that may use it) can call setStatus as that is essentially the only front-end thing that needs to be changed. Not exactly sure how this can be done simply because it seems that we can't pass setState functions through router.push without errors as of right now. 

I would say that we shouldn't need to refetch the case or case status when navigating between CaseScreen, Eligibility Form, and Case Summary. The case data should just remain constant I believe, and the status should be updated through a useState variable. Additionally, we should set up dynamic routing for the CaseScreen.

## Relevant Links

### Online sources

[//]: # 'Optional - copy links to any tutorials or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

CC: @stephaniewong2
